### PR TITLE
Fix deprecated torch.cuda.amp

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -76,7 +76,7 @@ class KokoroTrainer:
         # Check device support for mixed precision
         if self.use_mixed_precision:
             if self.device.type == DeviceType.CUDA.value:
-                self.scaler = torch.cuda.amp.GradScaler('cuda',
+                self.scaler = torch.amp.GradScaler('cuda',
                     init_scale=getattr(config, 'amp_init_scale', 65536.0),
                     growth_factor=getattr(config, 'amp_growth_factor', 2.0),
                     backoff_factor=getattr(config, 'amp_backoff_factor', 0.5),

--- a/trainer.py
+++ b/trainer.py
@@ -195,7 +195,7 @@ class KokoroTrainer:
             return torch.no_grad().__enter__()  # No-op context
 
         if self.device_type == DeviceType.CUDA.value:
-            return torch.cuda.amp.autocast('cuda')
+            return torch.amp.autocast('cuda')
         elif self.device_type == DeviceType.MPS.value:
             return torch.autocast(device_type='mps', dtype=self.mixed_precision_dtype)
         else:


### PR DESCRIPTION
`torch.cuda.amp.GradScaler` and `torch.cuda.amp.autocast` are deprecated and cause issues with device type `cuda`
don't work with device `cuda`.
This change replaces deprecated functions accordingly. See https://docs.pytorch.org/docs/stable/amp.html for the reference.